### PR TITLE
Provide a list for selecting peeps

### DIFF
--- a/src/helpers/peepSelection.ts
+++ b/src/helpers/peepSelection.ts
@@ -3,73 +3,104 @@ import * as btn from "./buttonControl";
 import { debug } from "./logger";
 import { followPeep } from "./resetViewport";
 import { selectedPeep, setSelectedPeep } from "./selectedPeep";
-import { getColourStaff, getCoordinates, getCostume, getEnergy, getFreeze, getLblColourStaff, getStaffType } from "./staffGetters";
+import {
+    getColourStaff,
+    getCoordinates,
+    getCostume,
+    getEnergy,
+    getFreeze,
+    getLblColourStaff,
+    getStaffType,
+} from "./staffGetters";
 import { windowId } from "./windowProperties";
 
-export function peepSelect(): void
-{
-    if (ui.getWindow(windowId).findWidget<ButtonWidget>("button-all-guests").isPressed){
+export function peepSelect(): void {
+    if (
+        ui.getWindow(windowId).findWidget<ButtonWidget>("button-all-guests")
+            .isPressed
+    ) {
         btn.toggle("button-all-guests");
     }
-    if (!ui.getWindow(windowId).findWidget<ButtonWidget>("button-picker").isPressed) {
+    if (
+        !ui.getWindow(windowId).findWidget<ButtonWidget>("button-picker")
+            .isPressed
+    ) {
         ui.activateTool({
             id: "select-peep",
             cursor: "cross_hair",
-            onDown: e => {
+            onDown: (e) => {
                 const entityId = e.entityId;
-                if (entityId !== undefined)
-                {
-                    const entity = map.getEntity(entityId);
-                    if (!entity || entity.type === "car")
-                    {
-                        ui.showError("You need Basssiiie's", "Ride Vehicle Editor");
-                        return;
+                if (entityId !== undefined) {
+                    const result = selectPeepByEntityId(entityId);
+                    if (result) {
+                        btn.toggle("button-picker");
+                        ui.tool?.cancel();
                     }
-                    else if (!entity || (entity.type !== "guest" && entity.type !== "staff"))
-                    {
-                        debug(`Invalid entity type selected: ${entity.type}`);
-                        ui.showError("You must select a guest", "or staff member");
-                        return;
-                    }
-                    setSelectedPeep(<Guest|Staff>entity);
-                    getFreeze(<Staff>selectedPeep);
-                    followPeep(selectedPeep);
-                    setLabelPeepName();
-                    btn.toggle("button-picker");
-                    btn.enableAll();
-                    if (entity.type === "guest") {btn.disable("button-freeze"); openSideWindow("Guest properties"); getColourGuest(<Guest>selectedPeep);}
-                    else
-                    {
-                        openSideWindow("Staff member properties");
-                        getColourStaff(<Staff>selectedPeep);
-                        getLblColourStaff(<Staff>selectedPeep);
-                        getCostume(<Staff>selectedPeep);
-                        getStaffType(<Staff>selectedPeep);
-                        getCoordinates(<Staff>selectedPeep);
-                        getEnergy(<Staff>selectedPeep);
-                    }
-                    ui.tool?.cancel();
                 }
-            }
+            },
         });
-    }
-    else {
+    } else {
         ui.tool?.cancel();
     }
     btn.toggle("button-picker");
 }
 
-export function setLabelPeepName(): void
-{
+export function selectPeepByEntityId(entityId: number): boolean {
+    const entity = map.getEntity(entityId);
+    if (!entity) {
+        ui.showError("This entity no longer exists.", "Peep selection");
+        return false;
+    }
+
+    if (!entity || entity.type === "car") {
+        ui.showError("You need Basssiiie's", "Ride Vehicle Editor");
+        return false;
+    } else if (
+        !entity ||
+        (entity.type !== "guest" && entity.type !== "staff")
+    ) {
+        debug(`Invalid entity type selected: ${entity.type}`);
+        ui.showError("You must select a guest", "or staff member");
+        return false;
+    }
+
+    setSelectedPeep(<Guest | Staff>entity);
+    getFreeze(<Staff>selectedPeep);
+    followPeep(selectedPeep);
+    setLabelPeepName();
+
+    btn.enableAll();
+    if (entity.type === "guest") {
+        btn.disable("button-freeze");
+        openSideWindow("Guest properties");
+        getColourGuest(<Guest>selectedPeep);
+    } else {
+        openSideWindow("Staff member properties");
+        getColourStaff(<Staff>selectedPeep);
+        getLblColourStaff(<Staff>selectedPeep);
+        getCostume(<Staff>selectedPeep);
+        getStaffType(<Staff>selectedPeep);
+        getCoordinates(<Staff>selectedPeep);
+        getEnergy(<Staff>selectedPeep);
+    }
+    return true;
+}
+export function setLabelPeepName(): void {
     const window = ui.getWindow(windowId);
-        window.findWidget<LabelWidget>("label-peep-name").text = `{WHITE}${selectedPeep.name}`;
+    window.findWidget<LabelWidget>("label-peep-name").text =
+        `{WHITE}${selectedPeep.name}`;
 }
 
-function getColourGuest(guest: Guest): void
-{
-	sideWindow.findWidget<ColourPickerWidget>("colourpicker-tshirt").colour = guest.tshirtColour;
-	sideWindow.findWidget<ColourPickerWidget>("colourpicker-trousers").colour = guest.trousersColour;
-	sideWindow.findWidget<ColourPickerWidget>("colourpicker-balloon").colour = guest.balloonColour;
-	sideWindow.findWidget<ColourPickerWidget>("colourpicker-hat").colour = guest.hatColour;
-	sideWindow.findWidget<ColourPickerWidget>("colourpicker-umbrella").colour = guest.umbrellaColour;
+function getColourGuest(guest: Guest): void {
+    sideWindow.findWidget<ColourPickerWidget>("colourpicker-tshirt").colour =
+        guest.tshirtColour;
+    sideWindow.findWidget<ColourPickerWidget>("colourpicker-trousers").colour =
+        guest.trousersColour;
+    sideWindow.findWidget<ColourPickerWidget>("colourpicker-balloon").colour =
+        guest.balloonColour;
+    sideWindow.findWidget<ColourPickerWidget>("colourpicker-hat").colour =
+        guest.hatColour;
+    sideWindow.findWidget<ColourPickerWidget>("colourpicker-umbrella").colour =
+        guest.umbrellaColour;
 }
+

--- a/src/helpers/selectedPeep.ts
+++ b/src/helpers/selectedPeep.ts
@@ -1,14 +1,28 @@
 import { staffType } from "../enums/staffTypes";
 
-export let selectedPeep: Guest|Staff;
+export let selectedPeep: Guest | Staff;
 let selectedStaff: Staff;
 export let selectedStaffType: number = -1;
 export let selectedStaffCostume: number = -1;
 
-export function setSelectedPeep(entity: Guest|Staff): void
-{
+let onPeepSelectedCallbacks: ((entity: Guest | Staff) => void)[] = [];
+
+export function setSelectedPeep(entity: Guest | Staff): void {
     selectedPeep = entity;
     selectedStaff = <Staff>selectedPeep;
     selectedStaffCostume = selectedStaff.costume;
     selectedStaffType = staffType.indexOf(selectedStaff.staffType);
+    onPeepSelectedCallbacks.forEach((callback) => callback(entity));
 }
+
+export function onPeepSelect(
+    callback: (entity: Guest | Staff) => void,
+): () => void {
+    onPeepSelectedCallbacks.push(callback);
+    return () => {
+        onPeepSelectedCallbacks = onPeepSelectedCallbacks.filter(
+            (cb) => cb !== callback,
+        );
+    };
+}
+

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -1,13 +1,15 @@
-import { colour } from "../enums/colours";
 import { selectPeepByEntityId } from "../helpers/peepSelection";
 import { onPeepSelect } from "../helpers/selectedPeep";
-import { margin, toolbarHeight } from "../helpers/windowProperties";
+import {
+    margin,
+    toolbarHeight,
+    windowColour,
+} from "../helpers/windowProperties";
 
 const guestSelectWindowId = "peep-editor-guest-select-window";
 
 const windowWidth = 300;
 const windowHeight = 500;
-const windowColour = colour["Saturated red"];
 
 // TODO: Use tabs instead of separators so we can sort.
 const peepListColumns: ListViewDesc["columns"] = [
@@ -124,7 +126,7 @@ class GuestSelectWindow {
         if (!window) {
             window = ui.openWindow({
                 classification: guestSelectWindowId,
-                title: "Select a guest",
+                title: "Peep Editor - Select a peep",
                 x: ui.width - windowWidth / 8 - windowWidth,
                 y: ui.height / 8 - windowHeight / 8,
                 width: windowWidth,

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -9,21 +9,22 @@ const windowWidth = 300;
 const windowHeight = 500;
 const windowColour = colour["Saturated red"];
 
+// TODO: Use tabs instead of separators so we can sort.
 const peepListColumns: ListViewDesc["columns"] = [
     {
         header: "ID",
-        // FIXME: Crashes the game?
-        // canSort: true,
+        // Crashes the game due to our use of separators.
+        canSort: false,
     },
     {
         header: "Name",
-        // FIXME: Crashes the game?
-        // canSort: true,
+        // Crashes the game due to our use of separators.
+        canSort: false,
     },
     {
         header: "Type",
-        // FIXME: Crashes the game?
-        // canSort: true,
+        // Crashes the game due to our use of separators.
+        canSort: false,
     },
 ];
 

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -81,11 +81,10 @@ class GuestSelectWindow {
             }
 
             if (selectedIndex !== -1) {
-                // FIXME: OpenRCT does not properly invalidate the window when this is called.
-                // peepList.selectedCell = {
-                //     column: 0,
-                //     row: selectedIndex,
-                // };
+                peepList.selectedCell = {
+                    column: 0,
+                    row: selectedIndex,
+                };
             }
         });
     }

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -1,0 +1,100 @@
+import { colour } from "../enums/colours";
+import { selectPeepByEntityId } from "../helpers/peepSelection";
+import { margin, toolbarHeight } from "../helpers/windowProperties";
+
+const guestSelectWindowId = "peep-editor-guest-select-window";
+
+const windowWidth = 300;
+const windowHeight = 500;
+const windowColour = colour["Saturated red"];
+
+class GuestSelectWindow {
+    // TODO: Tabs for these.
+    capturedGuests: Guest[] = [];
+    capturedStaff: Staff[] = [];
+
+    refresh(): void {
+        this.capturedGuests = map.getAllEntities("guest");
+        this.capturedStaff = map.getAllEntities("staff");
+    }
+
+    getPeepFromListboxIndex(index: number): Guest | Staff | null {
+        if (index === 0) {
+            // Guests header
+            return null;
+        }
+        index -= 1;
+        if (index < this.capturedGuests.length) {
+            return this.capturedGuests[index];
+        } else if (index === this.capturedGuests.length) {
+            // Staff header
+            return null;
+        } else {
+            index -= 1;
+            const staffIndex = index - this.capturedGuests.length;
+            if (staffIndex < this.capturedStaff.length) {
+                return this.capturedStaff[staffIndex];
+            }
+        }
+        return null;
+    }
+
+    open(): void {
+        this.refresh();
+        const window = ui.getWindow(guestSelectWindowId);
+        if (window) {
+            window.bringToFront();
+        } else {
+            ui.openWindow({
+                classification: guestSelectWindowId,
+                title: "Select a guest",
+                x: ui.width / 8 - windowWidth / 8 + windowWidth,
+                y: ui.height / 8 - windowHeight / 8,
+                width: windowWidth,
+                height: windowHeight,
+                colours: [windowColour, windowColour],
+                widgets: [
+                    {
+                        type: "listview",
+                        x: margin,
+                        width: windowWidth - margin * 2,
+                        y: toolbarHeight + margin,
+                        height: windowHeight - toolbarHeight - margin * 2,
+                        columns: [
+                            {
+                                canSort: true,
+                                header: "ID",
+                            },
+                            {
+                                canSort: true,
+                                header: "Name",
+                            },
+                        ],
+                        items: [
+                            { type: "separator", text: "Guests" },
+                            ...this.capturedGuests.map((guest) => [
+                                String(guest.id ?? -1),
+                                guest.name ?? "<none>",
+                            ]),
+                            { type: "separator", text: "Staff" },
+                            ...this.capturedStaff.map((staff) => [
+                                String(staff.id ?? -1),
+                                staff.name ?? "<none>",
+                            ]),
+                        ],
+                        onClick: (item): void => {
+                            const peep = this.getPeepFromListboxIndex(item);
+                            if (peep && peep.id != null) {
+                                selectPeepByEntityId(peep.id);
+                            }
+                        },
+                    },
+                ],
+            });
+        }
+    }
+}
+
+const guestSelectWindow = new GuestSelectWindow();
+export default guestSelectWindow;
+

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -21,29 +21,11 @@ const peepListColumns: ListViewDesc["columns"] = [
         // Crashes the game due to our use of separators.
         canSort: false,
     },
-    {
-        header: "Type",
-        // Crashes the game due to our use of separators.
-        canSort: false,
-    },
 ];
 
 function peepListItem(peep: Guest | Staff): ListViewItem {
     const idStr = String(peep.id ?? -1);
-    if (isStaff(peep)) {
-        return [idStr, peep.name ?? "<none>", peep.staffType ?? "<none>"];
-    } else if (isGuest(peep)) {
-        return [idStr, peep.name ?? "<none>"];
-    } else {
-        return [idStr];
-    }
-}
-
-function isStaff(peep: Guest | Staff): peep is Staff {
-    return peep.type === "staff";
-}
-function isGuest(peep: Guest | Staff): peep is Guest {
-    return peep.type === "guest";
+    return [idStr, peep.name ?? "<none>"];
 }
 
 class GuestSelectWindow {

--- a/src/ui/guestSelectWindow.ts
+++ b/src/ui/guestSelectWindow.ts
@@ -1,5 +1,6 @@
 import { colour } from "../enums/colours";
 import { selectPeepByEntityId } from "../helpers/peepSelection";
+import { onPeepSelect } from "../helpers/selectedPeep";
 import { margin, toolbarHeight } from "../helpers/windowProperties";
 
 const guestSelectWindowId = "peep-editor-guest-select-window";
@@ -8,10 +9,96 @@ const windowWidth = 300;
 const windowHeight = 500;
 const windowColour = colour["Saturated red"];
 
+const peepListColumns: ListViewDesc["columns"] = [
+    {
+        header: "ID",
+        // FIXME: Crashes the game?
+        // canSort: true,
+    },
+    {
+        header: "Name",
+        // FIXME: Crashes the game?
+        // canSort: true,
+    },
+    {
+        header: "Type",
+        // FIXME: Crashes the game?
+        // canSort: true,
+    },
+];
+
+function peepListItem(peep: Guest | Staff): ListViewItem {
+    const idStr = String(peep.id ?? -1);
+    if (isStaff(peep)) {
+        return [idStr, peep.name ?? "<none>", peep.staffType ?? "<none>"];
+    } else if (isGuest(peep)) {
+        return [idStr, peep.name ?? "<none>"];
+    } else {
+        return [idStr];
+    }
+}
+
+function isStaff(peep: Guest | Staff): peep is Staff {
+    return peep.type === "staff";
+}
+function isGuest(peep: Guest | Staff): peep is Guest {
+    return peep.type === "guest";
+}
+
 class GuestSelectWindow {
+    constructor() {
+        // Synchronize the list selection with the picker.
+        onPeepSelect((selectedPeep) => {
+            const peepList = this.peepList;
+            if (!peepList) {
+                return;
+            }
+
+            this.refresh();
+            let selectedIndex = -1;
+            switch (selectedPeep.type) {
+                case "guest":
+                    selectedIndex = findIndex(
+                        this.capturedGuests,
+                        (guest) => guest.id === selectedPeep.id,
+                    );
+                    if (selectedIndex !== -1) {
+                        // + 1 for guest header.
+                        selectedIndex += 1;
+                    }
+                    break;
+                case "staff":
+                    selectedIndex = findIndex(
+                        this.capturedStaff,
+                        (staff) => staff.id === selectedPeep.id,
+                    );
+                    if (selectedIndex !== -1) {
+                        selectedIndex += this.capturedGuests.length + 2; // +1 for guest header, +1 for staff header.
+                    }
+
+                    break;
+            }
+
+            if (selectedIndex !== -1) {
+                // FIXME: OpenRCT does not properly invalidate the window when this is called.
+                // peepList.selectedCell = {
+                //     column: 0,
+                //     row: selectedIndex,
+                // };
+            }
+        });
+    }
     // TODO: Tabs for these.
     capturedGuests: Guest[] = [];
     capturedStaff: Staff[] = [];
+
+    get peepList(): ListViewWidget | null {
+        const window = this.getWindow();
+        if (!window) {
+            return null;
+        }
+        return window.findWidget("list-peeps") as ListViewWidget | null;
+    }
 
     refresh(): void {
         this.capturedGuests = map.getAllEntities("guest");
@@ -39,16 +126,24 @@ class GuestSelectWindow {
         return null;
     }
 
-    open(): void {
-        this.refresh();
-        const window = ui.getWindow(guestSelectWindowId);
-        if (window) {
-            window.bringToFront();
-        } else {
-            ui.openWindow({
+    onListViewClick(index: number): void {
+        const peep = this.getPeepFromListboxIndex(index);
+        if (peep && peep.id != null) {
+            selectPeepByEntityId(peep.id);
+        }
+    }
+
+    getWindow(): Window | null {
+        return ui.getWindow(guestSelectWindowId);
+    }
+
+    getOrCreateWindow(): Window {
+        let window = this.getWindow();
+        if (!window) {
+            window = ui.openWindow({
                 classification: guestSelectWindowId,
                 title: "Select a guest",
-                x: ui.width / 8 - windowWidth / 8 + windowWidth,
+                x: ui.width - windowWidth / 8 - windowWidth,
                 y: ui.height / 8 - windowHeight / 8,
                 width: windowWidth,
                 height: windowHeight,
@@ -56,43 +151,43 @@ class GuestSelectWindow {
                 widgets: [
                     {
                         type: "listview",
+                        name: "list-peeps",
                         x: margin,
                         width: windowWidth - margin * 2,
                         y: toolbarHeight + margin,
                         height: windowHeight - toolbarHeight - margin * 2,
-                        columns: [
-                            {
-                                canSort: true,
-                                header: "ID",
-                            },
-                            {
-                                canSort: true,
-                                header: "Name",
-                            },
-                        ],
+                        columns: peepListColumns,
+                        showColumnHeaders: true,
+                        canSelect: true,
                         items: [
                             { type: "separator", text: "Guests" },
-                            ...this.capturedGuests.map((guest) => [
-                                String(guest.id ?? -1),
-                                guest.name ?? "<none>",
-                            ]),
+                            ...this.capturedGuests.map(peepListItem),
                             { type: "separator", text: "Staff" },
-                            ...this.capturedStaff.map((staff) => [
-                                String(staff.id ?? -1),
-                                staff.name ?? "<none>",
-                            ]),
+                            ...this.capturedStaff.map(peepListItem),
                         ],
                         onClick: (item): void => {
-                            const peep = this.getPeepFromListboxIndex(item);
-                            if (peep && peep.id != null) {
-                                selectPeepByEntityId(peep.id);
-                            }
+                            this.onListViewClick(item);
                         },
                     },
                 ],
             });
         }
+        return window;
     }
+
+    open(): void {
+        this.refresh();
+        this.getOrCreateWindow().bringToFront();
+    }
+}
+
+function findIndex(array: any[], predicate: (item: any) => boolean): number {
+    for (let i = 0; i < array.length; i++) {
+        if (predicate(array[i])) {
+            return i;
+        }
+    }
+    return -1;
 }
 
 const guestSelectWindow = new GuestSelectWindow();

--- a/src/ui/mainWindow.ts
+++ b/src/ui/mainWindow.ts
@@ -20,23 +20,13 @@ import * as button from "../helpers/buttonControl";
 import { getEnergy } from "../helpers/staffGetters";
 import guestSelectWindow from "./guestSelectWindow";
 
-const groupboxName: GroupBoxDesc = {
-    type: "groupbox",
-    name: "groupbox-name",
-    text: "Name",
-    x: margin,
-    y: toolbarHeight + widgetLineHeight / 2,
-    height: widgetLineHeight * 2.5,
-    width: windowWidth - margin * 2,
-};
-
 const btnPeepList: ButtonDesc = {
     type: "button",
     name: "button-peep-list",
     x: margin,
-    y: groupboxName.y + groupboxName.height / 2.5,
-    height: btnSize * 0.6,
-    width: btnSize * 0.6,
+    y: toolbarHeight + btnSize / 2 + margin / 2,
+    height: btnSize,
+    width: btnSize,
     image: 5193, //group of guests
     border: false,
     tooltip: "Select from list of all guests and staff",
@@ -44,10 +34,21 @@ const btnPeepList: ButtonDesc = {
         guestSelectWindow.open();
     },
 };
+
+const groupboxName: GroupBoxDesc = {
+    type: "groupbox",
+    name: "groupbox-name",
+    text: "Name",
+    x: btnPeepList.x + btnPeepList.width + margin,
+    y: toolbarHeight + widgetLineHeight / 2,
+    height: widgetLineHeight * 2.5,
+    width: windowWidth - margin * 3 - btnPeepList.width,
+};
+
 const labelPeepName: LabelDesc = {
     type: "label",
     name: "label-peep-name",
-    x: groupboxName.x + margin + btnPeepList.width + margin,
+    x: groupboxName.x + margin,
     y: groupboxName.y + groupboxName.height / 2.5,
     height: widgetLineHeight,
     width: groupboxName.width - margin * 2 - widgetLineHeight,
@@ -219,8 +220,8 @@ export class PeepEditorWindow {
                 height: windowHeight,
                 colours: [windowColour, windowColour],
                 widgets: [
-                    groupboxName,
                     btnPeepList,
+                    groupboxName,
                     labelPeepName,
                     viewportPeep,
                     btnPicker,

--- a/src/ui/mainWindow.ts
+++ b/src/ui/mainWindow.ts
@@ -1,5 +1,13 @@
 import { debug } from "../helpers/logger";
-import { windowId, widgetLineHeight, windowWidth, windowColour, margin, btnSize, toolbarHeight } from "../helpers/windowProperties";
+import {
+    windowId,
+    widgetLineHeight,
+    windowWidth,
+    windowColour,
+    margin,
+    btnSize,
+    toolbarHeight,
+} from "../helpers/windowProperties";
 import { setPeepNameExecuteArgs } from "../gameActions/peepSetName";
 import { freezeStaffExecuteArgs } from "../gameActions/staffFreeze";
 import { removePeep } from "../gameActions/peepRemove";
@@ -10,226 +18,251 @@ import { openSideWindow, sideWindow } from "./sideWindow";
 import { selectedPeep } from "../helpers/selectedPeep";
 import * as button from "../helpers/buttonControl";
 import { getEnergy } from "../helpers/staffGetters";
+import guestSelectWindow from "./guestSelectWindow";
 
 const groupboxName: GroupBoxDesc = {
-	type: "groupbox",
-	name: "groupbox-name",
-	text: "Name",
-	x: margin,
-	y: toolbarHeight + widgetLineHeight / 2,
-	height: widgetLineHeight * 2.5,
-	width: windowWidth - margin * 2,
+    type: "groupbox",
+    name: "groupbox-name",
+    text: "Name",
+    x: margin,
+    y: toolbarHeight + widgetLineHeight / 2,
+    height: widgetLineHeight * 2.5,
+    width: windowWidth - margin * 2,
+};
+
+const btnPeepList: ButtonDesc = {
+    type: "button",
+    name: "button-peep-list",
+    x: margin,
+    y: groupboxName.y + groupboxName.height / 2.5,
+    height: btnSize * 0.6,
+    width: btnSize * 0.6,
+    image: 5193, //group of guests
+    border: false,
+    tooltip: "Select from list of all guests and staff",
+    onClick: () => {
+        guestSelectWindow.open();
+    },
 };
 const labelPeepName: LabelDesc = {
-	type: "label",
-	name: "label-peep-name",
-	x: groupboxName.x + margin,
-	y: groupboxName.y + groupboxName.height / 2.5,
-	height: widgetLineHeight,
-	width: groupboxName.width - margin * 2 - widgetLineHeight,
-	text: `{RED} No peep selected`,
-	textAlign: "centred",
+    type: "label",
+    name: "label-peep-name",
+    x: groupboxName.x + margin + btnPeepList.width + margin,
+    y: groupboxName.y + groupboxName.height / 2.5,
+    height: widgetLineHeight,
+    width: groupboxName.width - margin * 2 - widgetLineHeight,
+    text: `{RED} No peep selected`,
+    textAlign: "centred",
 };
 
 const viewportPeep: ViewportDesc = {
-	type: "viewport",
-	name: "viewport-peep",
-	x: margin,
-	y: groupboxName.y + groupboxName.height + margin,
-	height: btnSize * 6,
-	width: windowWidth - btnSize - margin * 2,
+    type: "viewport",
+    name: "viewport-peep",
+    x: margin,
+    y: groupboxName.y + groupboxName.height + margin,
+    height: btnSize * 6,
+    width: windowWidth - btnSize - margin * 2,
 };
 
 const btnPicker: ButtonDesc = {
-	type: "button",
-	name: "button-picker",
-	x: viewportPeep.x +viewportPeep.width,
-	y: viewportPeep.y,
-	height: btnSize,
-	width: btnSize,
-	image: context.getIcon("eyedropper"),
-	isPressed: false,
-	tooltip: "Select a peep to modify",
-	onClick: () => peepSelect(),
+    type: "button",
+    name: "button-picker",
+    x: viewportPeep.x + viewportPeep.width,
+    y: viewportPeep.y,
+    height: btnSize,
+    width: btnSize,
+    image: context.getIcon("eyedropper"),
+    isPressed: false,
+    tooltip: "Select a peep to modify",
+    onClick: () => peepSelect(),
 };
 
 const btnFreeze: ButtonDesc = {
-	type: "button",
-	name: "button-freeze",
-	x: btnPicker.x,
-	y: btnPicker.y + btnPicker.height,
-	height: btnSize,
-	width: btnSize,
-	image: 5182, //red-green flag
-	border: false,
-	isDisabled: true,
-	tooltip: "(Un)freeze staff member",
-	onClick: () => {
-		if (selectedPeep.energy !== 0) {
-			button.pressed("button-freeze");
-		}
-		else {
-			button.unpressed("button-freeze");
-		}
-		getEnergy(<Staff>selectedPeep);
-		context.executeAction("pe_freezestaff", freezeStaffExecuteArgs(<Staff>selectedPeep));
-}
+    type: "button",
+    name: "button-freeze",
+    x: btnPicker.x,
+    y: btnPicker.y + btnPicker.height,
+    height: btnSize,
+    width: btnSize,
+    image: 5182, //red-green flag
+    border: false,
+    isDisabled: true,
+    tooltip: "(Un)freeze staff member",
+    onClick: () => {
+        if (selectedPeep.energy !== 0) {
+            button.pressed("button-freeze");
+        } else {
+            button.unpressed("button-freeze");
+        }
+        getEnergy(<Staff>selectedPeep);
+        context.executeAction(
+            "pe_freezestaff",
+            freezeStaffExecuteArgs(<Staff>selectedPeep),
+        );
+    },
 };
 
 const btnName: ButtonDesc = {
-	type: "button",
-	name: "button-peep-name",
-	x: btnPicker.x,
-	y: btnFreeze.y + btnFreeze.height,
-	height: btnSize,
-	width: btnSize,
-	image: 5168, //name tag
-	border: false,
-	isDisabled: true,
-	tooltip: "Rename peep with longer name",
-	onClick: () => {
-		const window = ui.getWindow(windowId);
-		ui.showTextInput({
-			title: peepTypeTitle(selectedPeep),
-			description: peepTypeDescription(selectedPeep),
-			initialValue: `${selectedPeep.name}`,
-			callback: text => {
-				context.executeAction("pe_peepname", setPeepNameExecuteArgs(selectedPeep, text));
-					window.findWidget<LabelWidget>("label-peep-name").text = `{WHITE}${text}`;
-			}
-		});
-	}
+    type: "button",
+    name: "button-peep-name",
+    x: btnPicker.x,
+    y: btnFreeze.y + btnFreeze.height,
+    height: btnSize,
+    width: btnSize,
+    image: 5168, //name tag
+    border: false,
+    isDisabled: true,
+    tooltip: "Rename peep with longer name",
+    onClick: () => {
+        const window = ui.getWindow(windowId);
+        ui.showTextInput({
+            title: peepTypeTitle(selectedPeep),
+            description: peepTypeDescription(selectedPeep),
+            initialValue: `${selectedPeep.name}`,
+            callback: (text) => {
+                context.executeAction(
+                    "pe_peepname",
+                    setPeepNameExecuteArgs(selectedPeep, text),
+                );
+                window.findWidget<LabelWidget>("label-peep-name").text =
+                    `{WHITE}${text}`;
+            },
+        });
+    },
 };
 
 const btnLocate: ButtonDesc = {
-	type: "button",
-	name: "button-locate",
-	x: btnPicker.x,
-	y: btnName.y + btnName.height,
-	height: btnSize,
-	width: btnSize,
-	image: 5167, //locate
-	border: false,
-	isDisabled: true,
-	tooltip: "Go to selected peep",
-	onClick: () => ui.mainViewport.scrollTo(selectedPeep),
+    type: "button",
+    name: "button-locate",
+    x: btnPicker.x,
+    y: btnName.y + btnName.height,
+    height: btnSize,
+    width: btnSize,
+    image: 5167, //locate
+    border: false,
+    isDisabled: true,
+    tooltip: "Go to selected peep",
+    onClick: () => ui.mainViewport.scrollTo(selectedPeep),
 };
 
 const btnDelete: ButtonDesc = {
-	type: "button",
-	name: "button-delete",
-	x: btnPicker.x,
-	y: btnLocate.y + btnLocate.height,
-	height: btnSize,
-	width: btnSize,
-	image: 5165, //trashcan
-	border: false,
-	isDisabled: true,
-	tooltip: "Remove selected peep(s)",
-	onClick: () => removePeep(selectedPeep),
+    type: "button",
+    name: "button-delete",
+    x: btnPicker.x,
+    y: btnLocate.y + btnLocate.height,
+    height: btnSize,
+    width: btnSize,
+    image: 5165, //trashcan
+    border: false,
+    isDisabled: true,
+    tooltip: "Remove selected peep(s)",
+    onClick: () => removePeep(selectedPeep),
 };
 
 const btnAllGuests: ButtonDesc = {
-	type: "button",
-	name: "button-all-guests",
-	x: btnPicker.x,
-	y: btnDelete.y + btnDelete.height,
-	height: btnSize,
-	width: btnSize,
-	image: 5193, //group of guests
-	border: false,
-	isDisabled: false,
-	tooltip: "Select all guests",
-	onClick: () => activateAllGuests()
+    type: "button",
+    name: "button-all-guests",
+    x: btnPicker.x,
+    y: btnDelete.y + btnDelete.height,
+    height: btnSize,
+    width: btnSize,
+    image: 5193, //group of guests
+    border: false,
+    isDisabled: false,
+    tooltip: "Select all guests",
+    onClick: () => activateAllGuests(),
 };
 
 const labelAuthor: LabelDesc = {
-	type: "label",
-	name: "label-author",
-	x: margin,
-	y: viewportPeep.height +viewportPeep.y + margin / 2,
-	height: widgetLineHeight,
-	width: windowWidth - margin * 2,
-	isDisabled: true,
-	text: "Manticore-007 © 2022-2023",
-	textAlign: "centred",
+    type: "label",
+    name: "label-author",
+    x: margin,
+    y: viewportPeep.height + viewportPeep.y + margin / 2,
+    height: widgetLineHeight,
+    width: windowWidth - margin * 2,
+    isDisabled: true,
+    text: "Manticore-007 © 2022-2023",
+    textAlign: "centred",
 };
 
 const btnAbout: ButtonDesc = {
-	type: "button",
-	name: "button-about",
-	x: margin + 1,
-	y: labelAuthor.y,
-	height: 10,
-	width: 10,
-	image: 5129, //small info
-	border: false,
-	isDisabled: false,
-	onClick: () => openSideWindow("About"),
+    type: "button",
+    name: "button-about",
+    x: margin + 1,
+    y: labelAuthor.y,
+    height: 10,
+    width: 10,
+    image: 5129, //small info
+    border: false,
+    isDisabled: false,
+    onClick: () => openSideWindow("About"),
 };
 
 export class PeepEditorWindow {
+    /**
+     * Opens the window for the Peep Editor.
+     */
 
-	/**
-	 * Opens the window for the Peep Editor.
-	 */
-
-	open(): void {
-		const window = ui.getWindow(windowId);
-		const windowHeight = btnAbout.y + widgetLineHeight;
-		if (window) {
-			debug("The Peep Editor window is already shown.");
-			window.bringToFront();
-		}
-		else {
-			ui.openWindow({
-				classification: windowId,
-				title: "Peep Editor",
-				x: ui.width / 8 - windowWidth / 8,
-				y: ui.height / 8 - windowHeight / 8,
-				width: windowWidth,
-				height: windowHeight,
-				colours: [windowColour, windowColour],
-				widgets:
-					[
-						groupboxName,
-						labelPeepName,
-						viewportPeep,
-						btnPicker,
-						btnFreeze,
-						btnName,
-						btnLocate,
-						btnDelete,
-						btnAllGuests,
-						labelAuthor,
-						btnAbout
-					],
-				onClose: () => {
-					if (sideWindow) { sideWindow.close(); }
-					disableUpdateViewport();
-					ui.tool?.cancel();
-				},
-				onUpdate: () => {
-					const window = ui.getWindow(windowId);
-					if (sideWindow) {
-						sideWindow.x = window.x + window.width;
-						sideWindow.y = window.y;
-					}
-				}
-			});
-			resetViewport();
-		}
-	}
+    open(): void {
+        const window = ui.getWindow(windowId);
+        const windowHeight = btnAbout.y + widgetLineHeight;
+        if (window) {
+            debug("The Peep Editor window is already shown.");
+            window.bringToFront();
+        } else {
+            ui.openWindow({
+                classification: windowId,
+                title: "Peep Editor",
+                x: ui.width / 8 - windowWidth / 8,
+                y: ui.height / 8 - windowHeight / 8,
+                width: windowWidth,
+                height: windowHeight,
+                colours: [windowColour, windowColour],
+                widgets: [
+                    groupboxName,
+                    btnPeepList,
+                    labelPeepName,
+                    viewportPeep,
+                    btnPicker,
+                    btnFreeze,
+                    btnName,
+                    btnLocate,
+                    btnDelete,
+                    btnAllGuests,
+                    labelAuthor,
+                    btnAbout,
+                ],
+                onClose: () => {
+                    if (sideWindow) {
+                        sideWindow.close();
+                    }
+                    disableUpdateViewport();
+                    ui.tool?.cancel();
+                },
+                onUpdate: () => {
+                    const window = ui.getWindow(windowId);
+                    if (sideWindow) {
+                        sideWindow.x = window.x + window.width;
+                        sideWindow.y = window.y;
+                    }
+                },
+            });
+            resetViewport();
+        }
+    }
 }
 
-function peepTypeTitle(peep: Staff | Guest): string
-{
-	if (peep.peepType === "staff") { return "Staff member name"; }
-	else return "Guest's name";
+function peepTypeTitle(peep: Staff | Guest): string {
+    if (peep.peepType === "staff") {
+        return "Staff member name";
+    } else return "Guest's name";
 }
 
-function peepTypeDescription(peep: Staff | Guest): string
-{
-	if (peep.peepType === "staff") { return "Enter new name for this member of staff:"; }
-	else { return "Enter name for this guest:"; }
+function peepTypeDescription(peep: Staff | Guest): string {
+    if (peep.peepType === "staff") {
+        return "Enter new name for this member of staff:";
+    } else {
+        return "Enter name for this guest:";
+    }
 }
+

--- a/src/ui/mainWindow.ts
+++ b/src/ui/mainWindow.ts
@@ -20,16 +20,29 @@ import * as button from "../helpers/buttonControl";
 import { getEnergy } from "../helpers/staffGetters";
 import guestSelectWindow from "./guestSelectWindow";
 
+const btnPicker: ButtonDesc = {
+    type: "button",
+    name: "button-picker",
+    x: windowWidth - margin - btnSize,
+    y: toolbarHeight + btnSize / 2 + margin / 2,
+    height: btnSize,
+    width: btnSize,
+    image: context.getIcon("eyedropper"),
+    isPressed: false,
+    tooltip: "Select a peep to modify",
+    onClick: () => peepSelect(),
+};
+
 const btnPeepList: ButtonDesc = {
     type: "button",
     name: "button-peep-list",
-    x: margin,
+    x: btnPicker.x - btnSize - margin,
     y: toolbarHeight + btnSize / 2 + margin / 2,
     height: btnSize,
     width: btnSize,
     image: 5193, //group of guests
     border: false,
-    tooltip: "Select from list of all guests and staff",
+    tooltip: "Select from a list of all guests and staff",
     onClick: () => {
         guestSelectWindow.open();
     },
@@ -39,10 +52,10 @@ const groupboxName: GroupBoxDesc = {
     type: "groupbox",
     name: "groupbox-name",
     text: "Name",
-    x: btnPeepList.x + btnPeepList.width + margin,
+    x: margin,
     y: toolbarHeight + widgetLineHeight / 2,
     height: widgetLineHeight * 2.5,
-    width: windowWidth - margin * 3 - btnPeepList.width,
+    width: windowWidth - (windowWidth - btnPeepList.x) - margin * 2,
 };
 
 const labelPeepName: LabelDesc = {
@@ -65,24 +78,11 @@ const viewportPeep: ViewportDesc = {
     width: windowWidth - btnSize - margin * 2,
 };
 
-const btnPicker: ButtonDesc = {
-    type: "button",
-    name: "button-picker",
-    x: viewportPeep.x + viewportPeep.width,
-    y: viewportPeep.y,
-    height: btnSize,
-    width: btnSize,
-    image: context.getIcon("eyedropper"),
-    isPressed: false,
-    tooltip: "Select a peep to modify",
-    onClick: () => peepSelect(),
-};
-
 const btnFreeze: ButtonDesc = {
     type: "button",
     name: "button-freeze",
-    x: btnPicker.x,
-    y: btnPicker.y + btnPicker.height,
+    x: viewportPeep.x + viewportPeep.width,
+    y: viewportPeep.y,
     height: btnSize,
     width: btnSize,
     image: 5182, //red-green flag
@@ -106,7 +106,7 @@ const btnFreeze: ButtonDesc = {
 const btnName: ButtonDesc = {
     type: "button",
     name: "button-peep-name",
-    x: btnPicker.x,
+    x: btnFreeze.x,
     y: btnFreeze.y + btnFreeze.height,
     height: btnSize,
     width: btnSize,
@@ -135,7 +135,7 @@ const btnName: ButtonDesc = {
 const btnLocate: ButtonDesc = {
     type: "button",
     name: "button-locate",
-    x: btnPicker.x,
+    x: btnFreeze.x,
     y: btnName.y + btnName.height,
     height: btnSize,
     width: btnSize,
@@ -149,7 +149,7 @@ const btnLocate: ButtonDesc = {
 const btnDelete: ButtonDesc = {
     type: "button",
     name: "button-delete",
-    x: btnPicker.x,
+    x: btnFreeze.x,
     y: btnLocate.y + btnLocate.height,
     height: btnSize,
     width: btnSize,
@@ -163,7 +163,7 @@ const btnDelete: ButtonDesc = {
 const btnAllGuests: ButtonDesc = {
     type: "button",
     name: "button-all-guests",
-    x: btnPicker.x,
+    x: btnFreeze.x,
     y: btnDelete.y + btnDelete.height,
     height: btnSize,
     width: btnSize,


### PR DESCRIPTION
This PR adds a peep selector list option to the Peep Editor.

<img width="1303" height="853" alt="image" src="https://github.com/user-attachments/assets/43b726e4-24ad-4796-88cd-b7d66b541b5c" />

When peeps are too close together on one tile, selecting them with the piper tool becomes impossible.  While picking up and putting down a peep elsewhere can be workable, it may cause changes in the scenario random seed, which for complicated reasons may not be allowable.

By adding a list, it becomes possible to browse and select peeps regardless of their map position.

Features:
- Lists all guests and staff
- Shows entity number and staff type
- Selects peeps on click
- Highlights the currently selected peep in the list
  - Note: The list will not re-render correctly for this in OpenRCT v0.4.32 - I submitted a fix [here](https://github.com/OpenRCT2/OpenRCT2/pull/26350)

Currently, the list is not sortable, as the usage of list item separators causes a crash on sort in OpenRCT.  As an alternative to this, the window could swap between a guest-mode and staff-mode, removing the separators and allowing the list to be sorted.